### PR TITLE
removed ProjectCostByPeriod from EntityClasses.config

### DIFF
--- a/EasyProjects.ClientModel/EntityClasses.config
+++ b/EasyProjects.ClientModel/EntityClasses.config
@@ -514,32 +514,6 @@
       </Fields>
     </EntityClass>
 
-    <EntityClass Name="ProjectCostByPeriod" TableFunctionName="dbo.GetProjectsCostByPeriod(@accountId, @dateFrom, @dateTo)" PrimaryKeyField="ProjectID">
-      <Fields>
-        <Field Name="ProjectID" AccessType="ReadOnly" >
-          <Descriptor DataType="Integer" AccessType="ReadOnly"/>
-        </Field>
-        <Field Name="Cost" AccessType="Mandatory" Alias="Project_Cost">
-          <Descriptor DataType="Decimal" AccessType="ReadOnly"/>
-        </Field>
-        <Field Name="TimeCost" AccessType="Mandatory" Alias="Project_TimeCost">
-          <Descriptor DataType="Decimal" AccessType="ReadOnly"/>
-        </Field>
-        <Field Name="Expenses" AccessType="Mandatory" Alias="Project_Expenses">
-          <Descriptor DataType="Decimal" AccessType="ReadOnly"/>
-        </Field>
-        <Field Name="TotalCost" AccessType="Mandatory" Alias="Project_TotalCost">
-          <Descriptor DataType="Decimal" AccessType="ReadOnly"/>
-        </Field>
-        <Field Name="CostDate" AccessType="Mandatory" Alias="Project_CostDate">
-          <Descriptor DataType="Date" AccessType="ReadOnly"/>
-        </Field>
-      </Fields>
-      <ReferenceFields>
-        <ReferenceField Name="ProjectID" ReferencedEntity="Project" ReferenceType="Mandatory"/>
-      </ReferenceFields>
-    </EntityClass>
-
     <EntityClass Name="ProjectAggregatedValues" TableName="VV_ProjectAggregatedValues" PrimaryKeyField="ProjectID" EnableAPI="true">
       <Fields>
         <Field Name="ProjectID" Alias="ProjectAggregatedValues_Project_ProjectID" AccessType="ReadOnly">


### PR DESCRIPTION
При удалении кастомизации SelectableCostDates нужно удалить датасорс для отчётов ProjectsReportSourceByPeriod

[AB#40829](https://dev.azure.com/LogicSoft/EasyProjects/_workitems/edit/40829) - task

core - https://github.com/LogicSoftware/EasyProjects/pull/6107
EPReports - https://github.com/LogicSoftware/EPReports/pull/66
front - https://github.com/LogicSoftware/EPFrontend/pull/2456